### PR TITLE
Move bio into hero, delete About section

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -192,7 +192,7 @@ a:hover {
     color: var(--ink);
 }
 
-.hero-sub {
+.hero-intro {
     font-size: clamp(1.1rem, 2vw, 1.35rem);
     line-height: 1.55;
     color: var(--ink-soft);
@@ -200,11 +200,12 @@ a:hover {
     margin: 0 0 var(--space-4);
 }
 
-.hero-sub em {
-    font-family: var(--serif);
-    font-style: italic;
-    font-weight: 500;
-    color: var(--ink);
+.hero-intro p {
+    margin: 0 0 1em;
+}
+
+.hero-intro p:last-child {
+    margin-bottom: 0;
 }
 
 .hero-actions {
@@ -291,12 +292,6 @@ a:hover {
 }
 
 .prose p:last-child { margin-bottom: 0; }
-
-.prose-lg p {
-    font-size: 1.15rem;
-    line-height: 1.75;
-    margin-bottom: var(--space-3);
-}
 
 .section-newsletter {
     background: linear-gradient(180deg, var(--bg) 0%, #f5f2e9 100%);
@@ -459,7 +454,6 @@ a:hover {
 }
 
 @media (max-width: 480px) {
-    .nav-links li:nth-child(3) { display: none; }
     .hero-actions { flex-direction: column; align-items: stretch; }
     .btn { width: 100%; }
 }

--- a/index.html
+++ b/index.html
@@ -36,7 +36,6 @@
             <ul class="nav-links">
                 <li><a href="#newsletter">Newsletter</a></li>
                 <li><a href="#work">Work</a></li>
-                <li><a href="#about">About</a></li>
                 <li><a href="#contact">Contact</a></li>
                 <li><a class="nav-cta" href="#newsletter">Subscribe</a></li>
             </ul>
@@ -51,9 +50,11 @@
                 <h1 id="hero-heading" class="hero-heading">
                     I'm Ashish.
                 </h1>
-                <p class="hero-sub">
-                    I lead PM at Pepper Content where I build with AI. Each week I publish <em>Weekly AI Digest</em>, a signal-scored roundup of what actually matters.
-                </p>
+                <div class="hero-intro">
+                    <p>Leading agentic product experiences at Pepper. Previously built ad optimisation engines for Fortune 500 brands at CommerceIQ.</p>
+                    <p>Doing side-quests for fun. Weekly AI Digest goes out every week. AbilitatorAI is an enablement platform in the making.</p>
+                    <p>Before all of it, some electronics engineering at BITS Pilani, Goa.</p>
+                </div>
                 <div class="hero-actions">
                     <a class="btn btn-primary" href="#newsletter">Subscribe to the digest</a>
                     <a class="btn btn-ghost" href="#work">See my work</a>
@@ -122,18 +123,6 @@
                         </div>
                     </li>
                 </ol>
-            </div>
-        </section>
-
-        <section id="about" class="section" aria-labelledby="about-heading">
-            <div class="container container-narrow">
-                <p class="section-label">About</p>
-                <h2 id="about-heading" class="section-title">About</h2>
-                <div class="prose prose-lg">
-                    <p>Leading agentic product experiences at Pepper. Previously built ad optimisation engines for Fortune 500 brands at CommerceIQ.</p>
-                    <p>Doing side-quests for fun. Weekly AI Digest goes out every week. AbilitatorAI is an enablement platform in the making.</p>
-                    <p>Before all of it, some electronics engineering at BITS Pilani, Goa.</p>
-                </div>
             </div>
         </section>
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -34,7 +34,7 @@
     onScroll();
 
     if ('IntersectionObserver' in window) {
-        var revealTargets = document.querySelectorAll('.section, .hero-heading, .hero-sub, .hero-actions, .work-item');
+        var revealTargets = document.querySelectorAll('.section, .hero-heading, .hero-intro, .hero-actions, .work-item');
         revealTargets.forEach(function (el) { el.classList.add('reveal'); });
 
         var io = new IntersectionObserver(function (entries) {


### PR DESCRIPTION
The About section duplicated what already lives directly under the hero heading. Inline the three bio paragraphs as the hero intro and remove:

- the About section markup
- the `About` link in the nav (now `Newsletter · Work · Contact · Subscribe`)
- the `.prose-lg` styles, only used by About
- the mobile rule that hid the About link on small screens

Updates the JS reveal selector from `.hero-sub` to `.hero-intro` to match the new container.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSaC1hDjoYrVm8uzYS25jb)_