### PR TITLE
Fix work dates and add intern entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
                 <ol class="work-list">
                     <li class="work-item">
                         <div class="work-meta">
-                            <span class="work-dates">2024 to Present</span>
+                            <span class="work-dates">Sep 2025 to Present</span>
                         </div>
                         <div class="work-body">
                             <h3 class="work-role">Senior Product Manager, Pepper Content</h3>
@@ -103,12 +103,32 @@
 
                     <li class="work-item">
                         <div class="work-meta">
-                            <span class="work-dates">2021 to 2024</span>
+                            <span class="work-dates">Dec 2020 to Aug 2025</span>
                         </div>
                         <div class="work-body">
                             <h3 class="work-role">Product Manager and Senior Data Scientist, CommerceIQ</h3>
-                            <p>Owned products managing $XXXM+ in annual retail ad spend, building an AI/ML powered advertising engine helping brands optimize their retail media spends.</p>
+                            <p>Built products managing $XXXM+ in annual retail ad spend, building an AI/ML powered advertising engine helping brands optimize their retail media spends.</p>
                             <p class="work-link"><a href="https://commerceiq.ai" target="_blank" rel="noopener">commerceiq.ai <span aria-hidden="true">↗</span></a></p>
+                        </div>
+                    </li>
+
+                    <li class="work-item">
+                        <div class="work-meta">
+                            <span class="work-dates">Aug 2020 to Dec 2020</span>
+                        </div>
+                        <div class="work-body">
+                            <h3 class="work-role">AI Intern, Thinkster Math</h3>
+                            <p>AI engineering internship.</p>
+                        </div>
+                    </li>
+
+                    <li class="work-item">
+                        <div class="work-meta">
+                            <span class="work-dates">May 2020 to Jul 2020</span>
+                        </div>
+                        <div class="work-body">
+                            <h3 class="work-role">Cognitive Neuroscience Intern, Brighter Minds</h3>
+                            <p>Cognitive neuroscience research internship.</p>
                         </div>
                     </li>
 


### PR DESCRIPTION
Corrects the date ranges on existing entries and adds two pre-grad internships.

- Pepper: `Sep 2025 to Present` (was `2024 to Present`).
- CommerceIQ: `Dec 2020 to Aug 2025` (was `2021 to 2024`). Description switched from "Owned" to "Built" since the role is no longer current.
- Add **AI Intern, Thinkster Math** — `Aug 2020 to Dec 2020`.
- Add **Cognitive Neuroscience Intern, Brighter Minds** — `May 2020 to Jul 2020`.
- ACM IMX 2022 research entry stays at the bottom.

Notes:
- The two new intern entries use a one-line placeholder description that restates the role. Replace with real copy when convenient.
- `$XXXM+` in the CommerceIQ line is still a placeholder for the real ARR number.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSaC1hDjoYrVm8uzYS25jb)_